### PR TITLE
Quick fix for everything getting classified as external analysis

### DIFF
--- a/mail2misp/mail2misp.py
+++ b/mail2misp/mail2misp.py
@@ -284,7 +284,7 @@ class Mail2MISP():
                                                           to_ids=False, enforceWarninglist=False)
                 if email_object:
                     email_object.add_reference(attribute.uuid, 'contains')
-            elif domainname in self.config.externallist or self.urlsonly is False:  # External analysis
+            elif domainname in self.config.externallist and self.urlsonly is False:  # External analysis
                 attribute = self.misp_event.add_attribute('link', entry, category='External analysis',
                                                           to_ids=False, enforceWarninglist=False)
                 if email_object:


### PR DESCRIPTION
With the OR statement everything gets classified as external analysis when not running with --urlsonly.